### PR TITLE
Implement padding

### DIFF
--- a/includes/defaults.php
+++ b/includes/defaults.php
@@ -94,6 +94,8 @@ $s['etc_icon_sets'] = array(
 $s['pkmn_img_width'] = 40;
 // Pokémon icon height
 $s['pkmn_img_height'] = 30;
+// Pokémon icon padding
+$s['pkmn_img_padding'] = 1;
 // Amount of icons in one row of the sprite
 $s['pkmn_row_count'] = 32;
 

--- a/includes/growingpacker.php
+++ b/includes/growingpacker.php
@@ -21,6 +21,7 @@ class GrowingPacker
     
     private $permit_growth_w;
     private $permit_growth_h;
+    private $img_padding;
     
     /**
      * Fits size sorted blocks using a binary tree packing algorithm.
@@ -49,10 +50,11 @@ class GrowingPacker
         
         $this->permit_growth_w = $permit_growth_w;
         $this->permit_growth_h = $permit_growth_h;
+        $this->img_padding = Settings::get('pkmn_img_padding');
         
         // Set the initial sizes.
-        $w = isset($first_block) ? $first_block->w : 0;
-        $h = isset($first_block) ? $first_block->h : 0;
+        $w = isset($first_block) ? $first_block->w + $this->img_padding : 0;
+        $h = isset($first_block) ? $first_block->h + $this->img_padding : 0;
         $w = isset($initial_w) ? $initial_w : $w;
         $h = isset($initial_h) ? $initial_h : $h;
         
@@ -68,13 +70,16 @@ class GrowingPacker
         // Iterate over all our blocks and then either split or grow
         // nodes on the tree.
         foreach ($blocks as &$block) {
-            $node = $this->find_node($this->root, $block->w, $block->h);
+            $block_w = $block->w + $this->img_padding;
+            $block_h = $block->h + $this->img_padding;
+            
+            $node = $this->find_node($this->root, $block_w, $block_h);
             
             if ($node) {
-                $block->fit = $this->split_node($node, $block->w, $block->h);
+                $block->fit = $this->split_node($node, $block_w, $block_h);
             }
             else {
-                $block->fit = $this->grow_node($block->w, $block->h);
+                $block->fit = $this->grow_node($block_w, $block_h);
             }
         }
     }

--- a/includes/iconsprite.php
+++ b/includes/iconsprite.php
@@ -22,6 +22,8 @@ class IconSprite
     public $verbose;
     /** @var mixed[] Default sprites (base for a duplicate). */
     public $std_sprites = array();
+    /** @var int Image padding. */
+    public $img_padding;
     
     /**
      * Initializes the sprite.
@@ -33,6 +35,7 @@ class IconSprite
      */
     function __construct($width, $height, $sections, $verbose=false)
     {
+        $this->img_padding = Settings::get('pkmn_img_padding');
         $this->sprite = @imagecreatetruecolor($width, $height);
         imagesavealpha($this->sprite, true);
         $trnsp = @imagecolorallocatealpha($this->sprite, 0, 0, 0, 127);
@@ -59,18 +62,24 @@ class IconSprite
      */
     function add($icon)
     {
-        $x = $icon['fit']['x'];
-        $y = $icon['fit']['y'];
-        
-        // Put the other icons underneath the Pokémon icons.
-        if ($icon['section'] != 'pkmn') {
-            $y += $this->sections['pkmn'];
-        }
+        $x = $icon['fit']['x'] + $this->img_padding;
+        $y = $icon['fit']['y'] + $this->img_padding;
         $w = $icon['w'];
         $h = $icon['h'];
         $file = $icon['file'];
         $slug = $icon['slug'];
         $type = $icon['type'];
+        
+        // Put the other icons underneath the Pokémon icons.
+        if ($icon['section'] != 'pkmn') {
+            $y += $this->sections['pkmn'];
+        }
+        // Remove the padding we added to the Pokémon icons earlier.
+        // Hackish, I know...
+        if ($icon['section'] == 'pkmn') {
+            $w -= $this->img_padding;
+            $h -= $this->img_padding;
+        }
         
         $indicator = ($type == 'pkmn' ? $icon['name_display'].' (variation='.$icon['variation'].', subvariation='.$icon['subvariation'].', version='.$icon['version'].')' : $slug);
         

--- a/includes/iconstack.php
+++ b/includes/iconstack.php
@@ -21,6 +21,8 @@ class IconStack
     public $pkmn_img_width;
     /** @var int Pokémon sprite image height. */
     public $pkmn_img_height;
+    /** @var int Pokémon sprite image padding. */
+    public $pkmn_img_padding;
     /** @var int Amount of sprite images in one row. */
     public $pkmn_row_count;
     
@@ -52,10 +54,17 @@ class IconStack
      */
     public function __construct()
     {
-        $vars = array('pkmn_img_width', 'pkmn_img_height', 'pkmn_row_count');
+        $vars = array(
+            'pkmn_img_width',
+            'pkmn_img_height',
+            'pkmn_img_padding',
+            'pkmn_row_count',
+        );
         foreach ($vars as $var) {
             $this->$var = Settings::get($var);
         }
+        $this->pkmn_img_width += $this->pkmn_img_padding;
+        $this->pkmn_img_height += $this->pkmn_img_padding;
     }
     
     /**
@@ -125,13 +134,12 @@ class IconStack
             if ($type != 'pkmn') {
                 $y += $pkmn_sect_size['h'];
             }
-            
             $icon_info = array(
                 'std' => $is_standard,
                 'w' => $icon['w'],
                 'h' => $icon['h'],
-                'x' => $x,
-                'y' => $y,
+                'x' => $x + $this->pkmn_img_padding,
+                'y' => $y + $this->pkmn_img_padding,
                 'type' => $type,
                 'original' => $original,
                 'set' => $set,
@@ -176,8 +184,8 @@ class IconStack
         
         // The Pokémon icon sizes are always static.
         $sizes['pkmn'] = array(
-            'w' => Settings::get('pkmn_img_width'),
-            'h' => Settings::get('pkmn_img_height'),
+            'w' => $this->pkmn_img_width - $this->pkmn_img_padding,
+            'h' => $this->pkmn_img_height - $this->pkmn_img_padding,
         );
         // Define the sizes for other items.
         if (empty($this->type_tree['etc'])) {
@@ -207,7 +215,10 @@ class IconStack
                     continue(2);
                 }
             }
-            $sizes[$slug] = array('w' => $w, 'h' => $h);
+            $sizes[$slug] = array(
+                'w' => $w,
+                'h' => $h
+            );
         }
         $this->set_sizes = $sizes;
         return $this->set_sizes;
@@ -499,8 +510,8 @@ class IconStack
     public function get_etc_icon_stack_size()
     {
         return array(
-            'w' => $this->etc_sect_width,
-            'h' => $this->etc_sect_height,
+            'w' => $this->etc_sect_width + $this->img_padding,
+            'h' => $this->etc_sect_height + $this->img_padding,
         );
     }
     
@@ -523,8 +534,8 @@ class IconStack
         $height += $include_icon_sets ? $etc_size['h'] : 0;
         
         return array(
-            'w' => $width,
-            'h' => $height,
+            'w' => $width + $this->pkmn_img_padding,
+            'h' => $height + $this->pkmn_img_padding,
         );
     }
     

--- a/includes/iconstack.php
+++ b/includes/iconstack.php
@@ -381,6 +381,7 @@ class IconStack
         if (isset($range)) {
             $range = str_replace(',', '-', $range);
             $range = explode('-', $range);
+            $range[0] = $range[0] === '0' ? 1 : $range[0];
             if ($range[1] <= $range[0]) {
                 $range[1] = $range[0];
             }

--- a/pokesprite.php
+++ b/pokesprite.php
@@ -327,6 +327,7 @@ $icon_js = new IconJS();
 // This will be given to the SCSS, JS and overview generators.
 $icon_tree = $icon_stack->get_icon_type_tree();
 $set_sizes = $icon_stack->get_set_sizes();
+
 $icon_overview->set_icon_list($all_icons);
 $icon_styler->set_icon_list($all_icons);
 $icon_styler->set_icon_sizes($set_sizes);


### PR DESCRIPTION
Padding should make the spritesheet completely safe for retina displays, even when not using nearest neighbor resizing.